### PR TITLE
Fix typeof checking

### DIFF
--- a/create_own_module_list.js
+++ b/create_own_module_list.js
@@ -21,7 +21,7 @@ function createModuleList () {
     module.maintainer = module.url.split("/")[3];
     module.name = module.url.split("/")[4];
     module.maintainerURL = "";
-    if (typeof module.description !== undefined) {
+    if (typeof module.description === "undefined") {
       module.description = "";
     }
 

--- a/create_own_module_list.js
+++ b/create_own_module_list.js
@@ -21,7 +21,7 @@ function createModuleList () {
     module.maintainer = module.url.split("/")[3];
     module.name = module.url.split("/")[4];
     module.maintainerURL = "";
-    if (typeof module.description !== "undefined") {
+    if (typeof module.description !== undefined) {
       module.description = "";
     }
 


### PR DESCRIPTION
correct crash when using `npm run ownList` with no description in object

> magicmirror-3rd-party-modules@0.1.0 checkModules
> python3 scripts/check_modules.py

Traceback (most recent call last):
  File "/home/bugsounet/MagicMirror-3rd-Party-Modules/scripts/check_modules.py", line 462, in <module>
    check_modules()
  File "/home/bugsounet/MagicMirror-3rd-Party-Modules/scripts/check_modules.py", line 215, in check_modules
    module["description"] += " This module have been defined to work only with MMM-GoogleAssistant."
    ~~~~~~^^^^^^^^^^^^^^^
KeyError: 'description'